### PR TITLE
Update Shopify.md

### DIFF
--- a/docs/platform/instructions/en/latest/Actions/shopify.md
+++ b/docs/platform/instructions/en/latest/Actions/shopify.md
@@ -10,7 +10,7 @@ permalink: platform/instructions/en/latest/Actions/shopify
 
 **Overview**
 
-The Kore.ai XO Platform allows you to easily connect your Shopify Shop instance to find answers for your general queries.
+The Kore.ai XO Platform allows you to easily connect your Shopify Shop instance to find informations regarding Customer, Product and Orders.
 
 </container>
 
@@ -18,7 +18,7 @@ The Kore.ai XO Platform allows you to easily connect your Shopify Shop instance 
 
 **Authorization**
  
-To connect to Shopify Shop, Kore.ai uses basic authentication. The end-user can use pre-authorized credentials provided by the developer during the configuration process or their own authorization profile during the configuration process to let the end user authorize during the conversation. Learn More.
+The end-user can use pre-authorized credentials provided by the developer or their own authorization profile during the configuration process to let the end user authorize during the conversation.
  
  
  |Authorization Type                      | Basic |
@@ -29,11 +29,23 @@ To connect to Shopify Shop, Kore.ai uses basic authentication. The end-user can 
 
 **Pre-authorize the Integration**
  
- To make the integration process smoother for customers, you can pre-authorize it by providing the necessary authorization credentials to obtain the access token.
+To make the integration process smoother for customers, you can pre-authorize it by providing the necessary authorization credentials to obtain the API Access token.
 
-**Basic**
-
-To be entered.
+**Custom Auth or Private App**
+ 
+ 1. Navigate to Shopify Admin page.
+ 2. Create a custom app for a store in the Shopify admin page. 
+ 3. Authenticate the custom app by installing the app.
+ 4. Generate API credentials and the necessary API access tokens. Refer this link for more information related to custom apps (https://help.shopify.com/en/manual/apps/app-types/custom-apps)
+ 5. Configure the app with the following scopes to perform the actions provided by the Kore.ai XO platform.
+ 
+     i.  read_orders
+ 
+     ii.  read_products and
+ 
+     iii.  read_customers
+ 
+ 6. Provide the “Admin Api access token” and “Domain” provided by shopify in Kore.ai Pre-authorize the Integration.
   
 **Allow Users to Authorize the Integration**
  
@@ -61,7 +73,7 @@ This method requires the end user to provide credentials during the conversation
  
  <container>
 
-**What can be achieved by integrating Azure with the Kore.ai XO Platform?**
+**What can be achieved by integrating Shopify Shop with the Kore.ai XO Platform?**
  
  The Kore.ai XO Platform supports all common actions on Shopify with pre-built dialog templates that are ready to use.
  


### PR DESCRIPTION
The instructions for the "Pre-authorize the Integration" section had to be modified because Shopify Shop does not support Basic Auth. As a result, the instructions now accommodate Custom Auth or Private App authentication methods instead.

Tested the Shopify integration based on the instruction mentioned.